### PR TITLE
force version of reflect-metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "highlight.js": "^9.1.0",
     "lodash": "^3.10.1",
     "moment": "^2.10.6",
-    "reflect-metadata": "^0.1.2",
+    "reflect-metadata": "0.1.2",
     "rxjs": "5.0.0-beta.0",
     "systemjs": "^0.19.4",
     "zone.js": "0.5.10"


### PR DESCRIPTION
Fixes #1. Also doesn't build properly in other environments (like docker) without this fix.