### PR TITLE
Accept plan objects in addition to arrays

### DIFF
--- a/app/services/plan-service.ts
+++ b/app/services/plan-service.ts
@@ -67,11 +67,17 @@ export class PlanService {
     }
 
     createPlan(planName: string, planContent: string, planQuery): IPlan {
+        var parsedContent = JSON.parse(planContent);
+
+        if (Array.isArray(parsedContent)) {
+            parsedContent = parsedContent[0];
+        }
+
         var plan: IPlan = {
             id: this.PEV_PLAN_TAG + new Date().getTime().toString(),
             name: planName || 'plan created on ' + moment().format('LLL'),
             createdOn: new Date(),
-            content: JSON.parse(planContent)[0],
+            content: parsedContent,
             query: planQuery
         };
 


### PR DESCRIPTION
I’m using `auto_explain` to log analyses of function calls. When it’s configured to output JSON, the root element of the document is a single plan object instead of an array of plans. I noticed the visualiser doesn’t accept these without wrapping them in an array.

Thanks for writing this, it’s been really helpful for me in the last few days! :smile: